### PR TITLE
Fix npm 3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "merge-stream": "^0.1.6",
     "pako": "^0.2.7",
     "prismjs": "git+https://github.com/LeaVerou/prism.git#gh-pages",
+    "regenerator": "^0.8.41",
     "run-sequence": "^1.0.1",
     "svgo": "0.5.6",
     "uglifyify": "^2.6.0",

--- a/src/js/page/index.js
+++ b/src/js/page/index.js
@@ -12,7 +12,7 @@ if (/(iPhone|iPad);/.test(navigator.userAgent)) {
 }
 
 loadScripts(polyfillsNeeded, function() {
-  require('babelify/node_modules/babel-core/node_modules/regenerator/runtime');
+  require('regenerator/runtime');
   new (require('./main-controller'));
 }, function() {
   console.error("Failed to load polyfills");

--- a/src/js/svgo-worker/index.js
+++ b/src/js/svgo-worker/index.js
@@ -1,5 +1,5 @@
 "use strict";
-require('babelify/node_modules/babel-core/node_modules/regenerator/runtime');
+require('regenerator/runtime');
 
 ()=>{ // hack around weird regenerator polyfill
 var svg2js = require('svgo/lib/svgo/svg2js');

--- a/src/js/sw-null/index.js
+++ b/src/js/sw-null/index.js
@@ -1,4 +1,4 @@
-require('babelify/node_modules/babel-core/node_modules/regenerator/runtime');
+require('regenerator/runtime');
 
 var storage = require('../utils/storage');
 

--- a/src/js/sw/index.js
+++ b/src/js/sw/index.js
@@ -1,4 +1,4 @@
-require('babelify/node_modules/babel-core/node_modules/regenerator/runtime');
+require('regenerator/runtime');
 require("./cache-polyfill");
 
 var storage = require('../utils/storage');


### PR DESCRIPTION
npm 3 has flat dependencies, so the regeneratore/runtime dependency
can't be deeply nested anymore.