### PR TITLE
Enhance the ability to navigate by keyboard

### DIFF
--- a/src/css/components/_material-switch.scss
+++ b/src/css/components/_material-switch.scss
@@ -44,10 +44,12 @@
     left: 0;
     width: 20px;
     height: 20px;
-    border-radius: 10px;
+    border-radius: 20px;
     background: #fafafa;
-    box-shadow: 0 1px 3px rgba(#000, 0.5);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 
+                inset 0 0 0 2px transparent;
     overflow: hidden;
+    box-sizing: border-box;
     @include transition(all 0.15s ease-out);
     @include transform(translateZ(0));
 
@@ -80,6 +82,8 @@
 
     & .handle {
       @include transform(translate3d(17px, 0, 0));
+      box-shadow: 0 1px 3px rgba(0,0,0,0.5), 
+                inset 0 0 0 2px transparent;
 
       &::before {
         opacity: 1;

--- a/src/css/components/_material-tabs.scss
+++ b/src/css/components/_material-tabs.scss
@@ -9,7 +9,11 @@
   font-size: 0.9rem;
 
   & input {
-    display: none;
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
   }
 }
 
@@ -26,12 +30,16 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: 2px;
-    background: #00BCD4;
-    opacity: 0;
+    top: 0;
+    border-bottom: 2px solid transparent;
   }
 
-  & :checked + .selected {
-    opacity: 1;
+  & :checked + .selected,
+  & :focus + .selected {
+    border-color: #00BCD4;
+  }
+
+  & :focus + .selected {
+    background: transparentize(#fff, 0.9);
   }
 }

--- a/src/css/components/_settings.scss
+++ b/src/css/components/_settings.scss
@@ -24,7 +24,21 @@
   @include align-items(center);
 
   & input[type=checkbox] {
-    display: none;
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+  }
+
+  & input:focus + .material-switch {
+    .handle {
+      width: 25px;
+      height: 25px;
+      top: -5px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.5), 
+                inset 0 0 0 2px #3F51B5;
+    }
   }
 }
 

--- a/src/css/components/_toolbar.scss
+++ b/src/css/components/_toolbar.scss
@@ -8,10 +8,6 @@
 .menu-toolbar-item {
   & button {
     padding: 10px 12px;
-
-    &:focus {
-      outline: none;
-    }
   }
 
   & svg {


### PR DESCRIPTION
This PR is about adding focus styles for the following elements:
- Main menu button
- Material tabs
- The toggle / switch list

Currently, it's hard to use the app without a mouse. My mouse was not working and I noticed that while trying to use it with the keyboard. 