### PR TITLE
Fix possible typo in utils.js

### DIFF
--- a/src/js/page/utils.js
+++ b/src/js/page/utils.js
@@ -25,7 +25,7 @@ const entityMap = {
   "/": '&#x2F;'
 };
 
-export function escapeHTML(string) {
+export function escapeHTML(str) {
   return String(str).replace(/[&<>"'\/]/g, s => entityMap[s]);
 }
 


### PR DESCRIPTION
Unless you are referencing a global variable I'm not aware of... I think you meant to use `str` instead of `string`?