### PR TITLE
Import EventEmitter consistently across files

### DIFF
--- a/src/js/page/ui/settings.js
+++ b/src/js/page/ui/settings.js
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import { domReady } from '../utils';
 import MaterialSlider from './material-slider';


### PR DESCRIPTION
No other file imports EventEmitter using the default import, so I changed it to match the other files. 

I'm not sure if there is any difference...