### PR TITLE
Convert floatPrecision to number instead of string

### DIFF
--- a/src/js/svgo-worker/index.js
+++ b/src/js/svgo-worker/index.js
@@ -145,7 +145,7 @@ function* multipassCompress(settings) {
   });
 
   // Set floatPrecision across all the plugins
-  const floatPrecision = settings.floatPrecision;
+  const floatPrecision = Number(settings.floatPrecision);
 
   for (const plugin of Object.values(pluginsData)) {
     if (plugin.params && 'floatPrecision' in plugin.params) {


### PR DESCRIPTION
This seems to be accidentally removed here: https://github.com/jakearchibald/svgomg/commit/c5da12c59a810b05e94f80193251d73d1c66040d

Without it I see the following error when attempting to compress an svg file:

```
main-controller.js:268 Error: Minifying error: toFixed() digits argument must be between 0 and 20
```