### PR TITLE
Change 'prettify code' to 'prettify markup'

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -125,7 +125,7 @@
                 <label class="setting-item-toggle">
                   <input type="checkbox" name="pretty">
                   {% include "partials/material-switch.html" %}
-                  Prettify code
+                  Prettify markup
                 </label>
               </div>
               <div>


### PR DESCRIPTION
I have OCD... :)

But I guess this should be changed as well since 'code' was changed to 'markup' in a recent update.