### PR TITLE
Select only svg code without results text

### DIFF
--- a/src/css/components/_results.scss
+++ b/src/css/components/_results.scss
@@ -3,6 +3,7 @@
   color: #fff;
   padding: 12px 16px;
   z-index: 1;
+  user-select: none;
 
   @media (min-width: 640px) {
     background: #FFF;


### PR DESCRIPTION
When you whant copy svg code and try select all text by mouse or shortcut we have copied results statistic text.