### PR TITLE
Fix #124 - Timeout transitionend event

### DIFF
--- a/src/js/page/ui/view-toggler.js
+++ b/src/js/page/ui/view-toggler.js
@@ -1,9 +1,13 @@
 import { EventEmitter } from 'events';
 import { domReady } from '../utils';
 
+/**
+ * Tabs that toggle between showing the SVG image and XML markup.
+ */
 export default class ViewToggler extends EventEmitter {
   constructor() {
     super();
+    /** @type {HTMLFormElement | null} */
     this.container = null;
 
     domReady.then(() => {

--- a/src/js/page/utils.js
+++ b/src/js/page/utils.js
@@ -47,7 +47,7 @@ function transitionClassFunc({removeClass = false}={}) {
       if (el.classList.contains(className)) return Promise.resolve();
     }
 
-    return new Promise(resolve => {
+    const transitionEnd = new Promise(resolve => {
       const listener = event => {
         if (event.target != el) return;
         el.removeEventListener('webkitTransitionEnd', listener);
@@ -64,6 +64,10 @@ function transitionClassFunc({removeClass = false}={}) {
         el.classList[removeClass ? 'remove' : 'add'](className);
       });
     });
+
+    const transitionTimeout = new Promise(resolve => setTimeout(resolve, 1000));
+
+    return Promise.race([transitionEnd, transitionTimeout]);
   }
 }
 


### PR DESCRIPTION
Occasionally the image/markup tabs get stuck in Firefox and you can no longer switch between them. It seems that the `"transitionend"` event sometimes doesn't fire, and as a result the previous promise in the queue never resolves.

The quick fix is to add a timeout with `Promise.race`. Neither promise rejects, so it's sufficient here.