### PR TITLE
Update navigation link to README.md

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@
               </a>
             </li>
             <li>
-              <a href="https://github.com/jakearchibald/svgomg/blob/master/README.md" class="menu-item">
+              <a href="https://github.com/jakearchibald/svgomg/blob/main/README.md" class="menu-item">
                 <svg viewBox="0 0 24 24" class="icon"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
                 <span class="menu-item-text">About</span>
               </a>


### PR DESCRIPTION
Branch name was changed from `master` to `main`. The link currently redirects, but this avoids the need to do so.