### PR TITLE
Configure htmlmin's clean-css options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,6 +49,13 @@ async function html() {
       collapseInlineTagWhitespace: false,
       collapseWhitespace: true,
       decodeEntities: true,
+      minifyCSS: {
+        level: {
+          1: {
+            specialComments: 0
+          }
+        }
+      },
       minifyJS: true,
       removeAttributeQuotes: true,
       removeComments: true,


### PR DESCRIPTION
Should fix:

```
Source map error: Error: request failed with status 404
Resource URL: https://jakearchibald.github.io/svgomg/
Source Map URL: head.css.map
```

Another solution would be to disable sourcemaps for `head.css`.