### PR TITLE
Fix head.css source maps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ function css() {
     .pipe(gulpSourcemaps.init())
     .pipe(boundSass({ outputStyle: 'compressed' }))
     .pipe(gulpSourcemaps.write('./'))
-    .pipe(gulp.dest('build/css/'));
+    .pipe(gulp.dest('build/'));
 }
 
 
@@ -34,7 +34,7 @@ async function html() {
   const [config, changelog, headCSS] = await Promise.all([
     readJSON(`${__dirname}/src/config.json`),
     readJSON(`${__dirname}/src/changelog.json`),
-    fs.readFile(`${__dirname}/build/css/head.css`)
+    fs.readFile(`${__dirname}/build/head.css`)
   ]);
 
   return gulp.src('src/*.html')

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0">
     <link rel="preload" as="script" href="js/page.js">
     <link rel="preload" as="script" href="https://www.google-analytics.com/analytics.js">
-    <link rel="preload" as="style" href="css/all.css">
+    <link rel="preload" as="style" href="all.css">
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata">
     <style>{{headCSS|safe}}</style>
     <script>
@@ -188,7 +188,7 @@
         requestAnimationFrame(function() {
           requestAnimationFrame(function() {
             [
-              "css/all.css",
+              "all.css",
               "https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata"
             ].forEach(function(url) {
               var link = document.createElement('link');

--- a/src/js/sw/index.js
+++ b/src/js/sw/index.js
@@ -14,7 +14,7 @@ addEventListener('install', event => {
     await cache.addAll([
       './',
       'imgs/icon.png',
-      'css/all.css',
+      'all.css',
       'js/gzip-worker.js',
       'js/page.js',
       'js/prism-worker.js',


### PR DESCRIPTION
Currently head.css source maps are not loaded because the its path is
changed when inlined into index.html which doesn't have head.css.map in
the same folder.

I suggest to move css to top level as the easiest way to fix this
and avoid paths manipulation.