### PR TITLE
Fix logo on Safari

### DIFF
--- a/src/css/components/_main-menu.scss
+++ b/src/css/components/_main-menu.scss
@@ -176,6 +176,11 @@
   background: #f3f3f3;
   font-size: 0.9rem;
 
+  .logo {
+    width: 100%;
+    height: auto;
+  }
+
   & h1 {
     font-size: inherit;
     margin: 0;

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
         <div class="overlay"></div>
         <nav class="menu">
           <div class="app-title">
-            <svg viewBox="0 0 600 600"><path fill="#0097A7" d="M0 1.995h600V600H0z"/><path fill="#00bcd4" d="M0 0h600v395.68H0z"/><path d="M269.224 530.33 519 395.485H269.224V530.33zM214.35 91.847H519v303.638H214.35V91.847z" opacity=".22"/><path fill="#fff" d="M80 341.735h189.224V530.33H80z"/></svg>
+            <svg viewBox="0 0 600 600" class="logo"><path fill="#0097a7" d="M0 1.995h600V600H0z"/><path fill="#00bcd4" d="M0 0h600v395.68H0z"/><path d="M269.224 530.33 519 395.485H269.224V530.33zM214.35 91.847H519v303.638H214.35V91.847z" opacity=".22"/><path fill="#fff" d="M80 341.735h189.224V530.33H80z"/></svg>
             <div class="title-text">
               <h1>SVGOMG</h1>
               <p>Powered by <a href="https://github.com/svg/svgo">SVGO v{{ SVGO_VERSION }}</a></p>


### PR DESCRIPTION
I don't own an Apple device so this slipped :/

I just tested on BrowserStack and it seems that without `width`/`height`, the SVG overflows the menu. An alternative way would be to specify the `width`/`height` attributes in the SVG.

@jakearchibald Let me know which solution you prefer.