### PR TITLE
pan-zoom: use `MouseEvent.button` instead of `event.which`

### DIFF
--- a/src/js/page/ui/pan-zoom.js
+++ b/src/js/page/ui/pan-zoom.js
@@ -98,7 +98,7 @@ export default class PanZoom {
   }
 
   _onPointerDown(event) {
-    if (event.type == 'mousedown' && event.which != 1) return;
+    if (event.type == 'mousedown' && event.button !== 0) return;
     if (!this._shouldCaptureFunc(event.target)) return;
     event.preventDefault();
 


### PR DESCRIPTION
Not sure if there's something else behind this choice, but it seems to work fine.