### PR TITLE
Remove IE leftovers

### DIFF
--- a/src/css/components/_main-menu.scss
+++ b/src/css/components/_main-menu.scss
@@ -82,8 +82,7 @@
   & .menu-item {
     padding: 0 16px;
     width: 100%;
-    // I want this to be min-height, but IE breaks layout if I do
-    height: 48px;
+    min-height: 48px;
     box-sizing: border-box;
     display: flex;
     align-items: center;

--- a/src/css/components/_material-slider.scss
+++ b/src/css/components/_material-slider.scss
@@ -58,23 +58,11 @@
     position: absolute;
     top: 0;
     left: 0;
-    margin: 0;
-    width: 100%;
-
-    // increase the touch target
-    height: 60px;
-
-    @supports (width: calc(100% + 10px)) {
-      width: calc(100% + 10px);
-      margin-left: -5px;
-    }
+    margin: 0 0 0 -5px;
+    width: calc(100% + 10px);
+    height: 60px; // increase the touch target
     transform: translateY(-50%);
     opacity: 0;
-    
-    // remove tooltip in IE
-    &::-ms-tooltip {
-      display: none;
-    }
   }
 
   & :focus + .track,

--- a/src/js/page/svg-file.js
+++ b/src/js/page/svg-file.js
@@ -4,8 +4,7 @@ export default class SvgFile {
   constructor(text, width, height) {
     this.text = text;
     this._compressedSize = null;
-    this._url = '';
-    this._blob = null;
+    this._url = null;
     this.width = width;
     this.height = height;
   }
@@ -22,27 +21,19 @@ export default class SvgFile {
     return this._compressedSize;
   }
 
-  _create() {
-    // IE GCs blobs once they're out of reference, even if they
-    // have an object url, so we have to keep in in reference.
-    this._blob = new Blob([this.text], {type: "image/svg+xml"});
-    this._url = URL.createObjectURL(this._blob);
-  }
-
-  get blob() {
-    if (!this._blob) this._create();
-    return this._blob;
-  }
-
   get url() {
-    if (!this._url) this._create();
+    if (!this._url) {
+      this._url = URL.createObjectURL(
+        new Blob([this.text], { type: 'image/svg+xml' })
+      );
+    }
+
     return this._url;
   }
 
   release() {
     if (!this._url) return;
 
-    this._blob = null;
     URL.revokeObjectURL(this._url);
   }
 }

--- a/src/js/page/ui/download-button.js
+++ b/src/js/page/ui/download-button.js
@@ -14,25 +14,14 @@ export default class DownloadButton extends FloatingActionButton {
         '</svg>'
       )
     });
-
-    this._svgFile = null;
   }
 
   _onClick(event) {
     super._onClick(event);
-
-    // IE compat
-    if ('msSaveBlob' in navigator) {
-      event.preventDefault();
-      navigator.msSaveBlob(this._svgFile.blob, this._svgFile.filename);
-    }
   }
 
   setDownload(filename, svgFile) {
     this.container.download = filename;
     this.container.href = svgFile.url;
-
-    // for IE compat
-    this._svgFile = svgFile;
   }
 }

--- a/src/js/page/ui/material-slider.js
+++ b/src/js/page/ui/material-slider.js
@@ -42,7 +42,6 @@ export default class MaterialSlider {
     this.range.classList.add('active');
 
     const upListener = () => {
-      // IE requires me to do this. Pah.
       requestAnimationFrame(() => {
         this.range.blur();
       });


### PR DESCRIPTION
Basically reverts 027fd5abd29c080761f3259e63f8933b113275d1 and 6a9a33ec5248416eb918112a7843456b99e80ac9

I haven't tested this on Safari; Edge and Firefox work fine AFAICT.

Refs #254