### PR TITLE
view-toggler.js: remove workaround

### DIFF
--- a/src/js/page/ui/view-toggler.js
+++ b/src/js/page/ui/view-toggler.js
@@ -21,14 +21,8 @@ export default class ViewToggler {
   }
 
   _onChange() {
-    let value = this.container.output.value;
-
-    if (!value) { // some browsers don't support the nice shortcut above (eg Safari)
-      value = Array.from(this.container.output).reduce((value, input) => {
-        return value || (input.checked ? input.value : '');
-      }, '');
-    }
-
-    this.emitter.emit("change", { value });
+    this.emitter.emit('change', {
+      value: this.container.output.value
+    });
   }
 }


### PR DESCRIPTION
I tested this and I don't see any issues. Please confirm.

Closes #254 since I believe this is the last old browser workaround.