### PR TITLE
gulpfile: update html-minifier config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,9 +50,16 @@ async function html() {
       collapseInlineTagWhitespace: false,
       collapseWhitespace: true,
       decodeEntities: true,
+      minifyCSS: false,
       minifyJS: true,
       removeAttributeQuotes: true,
       removeComments: true,
+      removeOptionalTags: true,
+      removeRedundantAttributes: true,
+      removeScriptTypeAttributes: true,
+      removeStyleLinkTypeAttributes: true,
+      sortAttributes: true,
+      sortClassName: true
     }))
     .pipe(gulp.dest('build'));
 }


### PR DESCRIPTION
Enable a few more options.

I've been using these options for years without any issues; I explicitly added `minifyCSS: false` so that it's clear that it's not enabled by default and IMHO it should be enabled later.

These options should slightly improve compression.