### PR TITLE
index.html: remove redundant `requestAnimationFrame` call

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -190,27 +190,25 @@
         });
 
         requestAnimationFrame(function() {
-          requestAnimationFrame(function() {
-            [
-              'all.css',
-              'https://fonts.googleapis.com/css?family=Roboto:400,700%7CInconsolata'
-            ].forEach(function(url) {
-              var link = document.createElement('link');
-              link.rel = 'stylesheet';
-              link.crossorigin = true;
-              link.href = url;
+          [
+            'all.css',
+            'https://fonts.googleapis.com/css?family=Roboto:400,700%7CInconsolata'
+          ].forEach(function(url) {
+            var link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.crossorigin = true;
+            link.href = url;
 
-              document.head.appendChild(link);
-            });
+            document.head.appendChild(link);
+          });
 
-            [
-              'js/page.js',
-              'https://www.google-analytics.com/analytics.js'
-            ].forEach(function(url) {
-              var script = document.createElement('script');
-              script.src = url;
-              document.head.appendChild(script);
-            });
+          [
+            'js/page.js',
+            'https://www.google-analytics.com/analytics.js'
+          ].forEach(function(url) {
+            var script = document.createElement('script');
+            script.src = url;
+            document.head.appendChild(script);
           });
         });
       </script>


### PR DESCRIPTION
@jakearchibald I *think* this is redundant, but maybe I'm missing something :)

BTW would be nice to switch to `link` and `script` tags instead of the inline JS, assuming the outcome is the same.