### PR TITLE
index.html: change viewport meta to `initial-scale=1`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>SVGOMG - SVGO's Missing GUI</title>
     <meta name="theme-color" content="#303f9f">
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preload" as="script" href="js/page.js">
     <link rel="preload" as="script" href="https://www.google-analytics.com/analytics.js">
     <link rel="preload" as="style" href="all.css">


### PR DESCRIPTION
I guess we could also drop `initial-scale` altogether but I went with the safest solution