### PR TITLE
gulpfile.js: specify the host for sirv

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,6 +123,7 @@ function watch() {
 
 function serve() {
   sirv('build', {
+    host: 'localhost',
     port: 8080,
     dev: true,
     clear: false


### PR DESCRIPTION
`localhost` is the default for sirv-cli, but the API is using `0.0.0.0`. Now we are consistent.