### PR TITLE
index.html: switch to `apple-touch-icon`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
       window.version = "{{changelog[0].version}}";
     </script>
     <link rel="manifest" href="manifest.json">
-    <link rel="apple-touch-icon-precomposed" href="imgs/icon.png">
+    <link rel="apple-touch-icon" href="imgs/icon.png">
     <link rel="icon" href="imgs/icon.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="SVGOMG">


### PR DESCRIPTION
IIRC `apple-touch-icon-precomposed` was needed for old Safari versions.