### PR TITLE
Update pako to v2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "gulp-sass": "^5.0.0",
         "gulp-sourcemaps": "^3.0.0",
         "nanoevents": "^6.0.1",
-        "pako": "^1.0.11",
+        "pako": "^2.0.4",
         "prismjs": "^1.24.0",
         "rollup": "^2.56.3",
         "rollup-plugin-terser": "^7.0.2",
@@ -4340,9 +4340,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
       "dev": true
     },
     "node_modules/param-case": {
@@ -10286,9 +10286,9 @@
       }
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
       "dev": true
     },
     "param-case": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "nanoevents": "^6.0.1",
-    "pako": "^1.0.11",
+    "pako": "^2.0.4",
     "prismjs": "^1.24.0",
     "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",

--- a/src/js/gzip-worker/index.js
+++ b/src/js/gzip-worker/index.js
@@ -1,4 +1,4 @@
-import {gzip} from 'pako/lib/deflate';
+import { gzip } from 'pako/dist/pako_deflate.js';
 
 self.onmessage = function(event) {
   try {


### PR DESCRIPTION
While at it, I switched to their dist file. It seems they offer these files:

```
C:\Users\xmr\Desktop\svgomg\node_modules\pako\dist>dir /b *.js
pako.es5.js
pako.es5.min.js
pako.js
pako.min.js
pako_deflate.es5.js
pako_deflate.es5.min.js
pako_deflate.js
pako_deflate.min.js
pako_inflate.es5.js
pako_inflate.es5.min.js
pako_inflate.js
pako_inflate.min.js
```

I'm not sure if we should use something else. I tried `import { gzip } from 'pako';` but it seems it's including a lot more stuff obviously.