### PR TITLE
utils/storage.js: remove the iOS workaround

### DIFF
--- a/src/js/utils/storage.js
+++ b/src/js/utils/storage.js
@@ -1,4 +1,4 @@
-export let idbKeyval = (() => {
+export const idbKeyval = (() => {
   let db;
 
   function getDB() {
@@ -53,13 +53,3 @@ export let idbKeyval = (() => {
     }
   };
 })();
-
-// iOS add-to-homescreen is missing IDB, or at least it used to.
-// I haven't tested this in a while.
-if (!self.indexedDB) {
-  idbKeyval = {
-    get: key => Promise.resolve(localStorage.getItem(key)),
-    set: (key, val) => Promise.resolve(localStorage.setItem(key, val)),
-    delete: key => Promise.resolve(localStorage.removeItem(key))
-  };
-}


### PR DESCRIPTION
I tested things back to iOS 13 and it seems to work fine. iOS 12 doesn't work already on main.

Just so we are safe, someone should double check this. :)