### PR TITLE
Replace function expressions with callbacks

### DIFF
--- a/src/js/page/ui/spinner.js
+++ b/src/js/page/ui/spinner.js
@@ -23,13 +23,11 @@ export default class Spinner {
     this._showTimeout = null;
     this.container.style.display = 'none';
 
-    const animEndListener = event => {
+    this.container.addEventListener('animationend', (event) => {
       if (event.target == this.container) {
         this.container.style.display = 'none';
       }
-    };
-
-    this.container.addEventListener('animationend', animEndListener);
+    });
   }
 
   show(delay = 300) {


### PR DESCRIPTION
This was needed in the past due to the callback function's length, but now I think it's cleaner this way.