### PR TITLE
ripple: switch to a span

### DIFF
--- a/src/js/page/ui/ripple.js
+++ b/src/js/page/ui/ripple.js
@@ -2,7 +2,7 @@ import { strToEl } from '../utils';
 
 export default class Ripple {
   constructor() {
-    this.container = strToEl('<div class="ripple"></div>');
+    this.container = strToEl('<span class="ripple"></span>');
   }
 
   animate() {


### PR DESCRIPTION
I was checking the serialized DOM for HTML validation errors, and came across this one. AFAICT it's safe.

The rest of the errors are harder to tackle and some are intentional like the missing `link` `rel` attribute which is intentional.

The `section` warning is invalid too since we add a heading when there's changelog but perhaps we could add the section only if there's a reason to show the changelog?

The `scrolling` error is also valid but I couldn't make it work properly...

<img src="https://user-images.githubusercontent.com/349621/134709788-65c3f269-93bd-4bbd-a326-c9c14e58b32b.png" alt="val" width="500">

**EDIT**: Just found another one:

```
Bad value 350.66 for attribute width on element iframe: Expected a digit but saw . instead
```

If browsers round when this happens, we could probably do it ourselves too with `Math.round`?
