### PR TITLE
svg-output.js: use `Math.round`

### DIFF
--- a/src/js/page/ui/svg-output.js
+++ b/src/js/page/ui/svg-output.js
@@ -33,8 +33,8 @@ export default class SvgOutput {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1125667
     const nextLoad = this._nextLoadPromise();
     this._svgFrame.src = "data:image/svg+xml," + encodeURIComponent(svgFile.text);
-    this._svgFrame.width = svgFile.width;
-    this._svgFrame.height = svgFile.height;
+    this._svgFrame.width = Math.round(svgFile.width);
+    this._svgFrame.height = Math.round(svgFile.height);
     return nextLoad;
   }
 


### PR DESCRIPTION
Floating point values aren't valid here.

~~I think that's the reason I was still seeing the iframe scrollbars on Firefox when I tried to remove `scrolling="no"`. Chrome didn't have this issue. I haven't tried Safari yet.~~

~~EDIT: the issue with scrollbars showing still happens on Firefox after zooming in on some cases :/ I'm out of ideas.~~
EDIT2: either way, we should probably use `Math.round` since floating point values are valid in width/height attributes anyway...