### PR TITLE
svg-output: remove charset

### DIFF
--- a/src/js/page/ui/svg-output.js
+++ b/src/js/page/ui/svg-output.js
@@ -32,7 +32,7 @@ export default class SvgOutput {
     // All the internal refs break.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1125667
     const nextLoad = this._nextLoadPromise();
-    this._svgFrame.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgFile.text);
+    this._svgFrame.src = "data:image/svg+xml," + encodeURIComponent(svgFile.text);
     this._svgFrame.width = svgFile.width;
     this._svgFrame.height = svgFile.height;
     return nextLoad;


### PR DESCRIPTION
This shouldn't be needed.

BTW @jakearchibald I think it's worth looking into doing something like https://github.com/tigt/mini-svg-data-uri. I tried to incorporate the package, but I don't think we need all of its features. We just need to normalize quotes and then just escape the characters that need to be escaped. The savings are a lot and it probably makes a difference with big SVG files.