### PR TITLE
Use system font stack

### DIFF
--- a/src/css/_global.scss
+++ b/src/css/_global.scss
@@ -6,7 +6,7 @@ html, body {
 }
 
 html {
-  font-family: roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   line-height: 1.25;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
     </script>
     <script src="js/page.js" defer></script>
     <link rel="preload" as="style" href="all.css" onload="rel='stylesheet'">
-    <link rel="preload" crossorigin as="style" href="https://fonts.googleapis.com/css?family=Roboto:400,700%7CInconsolata" onload="rel='stylesheet'">
+    <link rel="preload" crossorigin as="style" href="https://fonts.googleapis.com/css?family=Inconsolata" onload="rel='stylesheet'">
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="imgs/icon.png">


### PR DESCRIPTION
Instead of Roboto, I used system font stack for everything except code output. For that, I left Inconsolata in place as monospace system fonts aren't as good yet as sans-serifs.

This is [the reasoning](https://github.com/jakearchibald/svgomg/issues/280#issuecomment-929083176) behind this decision.