### PR TITLE
_spinner.scss: remove unneeded `!important`

### DIFF
--- a/src/css/components/_spinner.scss
+++ b/src/css/components/_spinner.scss
@@ -1,5 +1,3 @@
-// stylelint-disable declaration-no-important
-
 @keyframes container-rotate {
   to { transform: rotate(360deg); }
 }
@@ -63,7 +61,7 @@
     border-width: 3px;
     border-style: solid;
     border-color: inherit;
-    border-bottom-color: transparent !important;
+    border-bottom-color: transparent;
     border-radius: 50%;
   }
 
@@ -94,14 +92,14 @@
     border-color: inherit;
 
     &.left .circle {
-      border-right-color: transparent !important;
+      border-right-color: transparent;
       transform: rotate(129deg);
       animation: left-spin 1333ms cubic-bezier(0.4, 0, 0.2, 1) infinite both;
     }
 
     &.right .circle {
       left: -100%;
-      border-left-color: transparent !important;
+      border-left-color: transparent;
       transform: rotate(-129deg);
       animation: right-spin 1333ms cubic-bezier(0.4, 0, 0.2, 1) infinite both;
     }


### PR DESCRIPTION
AFAICT:

* `border-bottom-color` comes after the `border` shorthand
* the other two cases have higher specificity