### PR TITLE
performance: removes lighthouse warning about passive scroll

### DIFF
--- a/src/js/page/ui/material-slider.js
+++ b/src/js/page/ui/material-slider.js
@@ -24,7 +24,7 @@ export default class MaterialSlider {
 
     rangeEl.addEventListener('input', () => this._onInputChange());
     this.range.addEventListener('mousedown', () => this._onRangeMouseDown());
-    this.range.addEventListener('touchstart', () => this._onRangeTouchStart());
+    this.range.addEventListener('touchstart', () => this._onRangeTouchStart(), { passive: true });
     this.range.addEventListener('touchend', () => this._onRangeTouchEnd());
 
     this._setPosition();

--- a/src/js/page/ui/pan-zoom.js
+++ b/src/js/page/ui/pan-zoom.js
@@ -95,10 +95,10 @@ export default class PanZoom {
 
     // bound events
     eventArea.addEventListener('mousedown', this._onPointerDown);
-    eventArea.addEventListener('touchstart', this._onPointerDown);
+    eventArea.addEventListener('touchstart', this._onPointerDown, { passive: true });
 
     // unbonud
-    eventArea.addEventListener('wheel', e => this._onWheel(e));
+    eventArea.addEventListener('wheel', e => this._onWheel(e), { passive: true });
   }
 
   reset() {

--- a/src/js/page/ui/settings.js
+++ b/src/js/page/ui/settings.js
@@ -33,7 +33,7 @@ export default class Settings {
       this._scroller = document.querySelector('.settings-scroller');
 
       this.container.addEventListener('input', e => this._onChange(e));
-      this._scroller.addEventListener('wheel', e => this._onMouseWheel(e));
+      this._scroller.addEventListener('wheel', e => this._onMouseWheel(e), { passive: true });
       this._resetBtn.addEventListener('click', e => this._onReset(e));
 
       // Stop double-tap text selection.


### PR DESCRIPTION
This fixes lighthouse warning about using `passive listeners to improve scrolling performance`:

![image](https://user-images.githubusercontent.com/42002892/135761215-aed222ba-eb5f-44bc-aca3-a8e7b963734d.png)

ive tested in home, let me know if i missed something

one of #311 tasks

please consider tagging it as 'hacktoberfest-accepted' 🥳