### PR TITLE
meta: add description meta tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,7 @@
     <link rel="icon" href="imgs/icon.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="SVGOMG">
-    <meta name="description" content="SVGOMG is SVGO's Missing GUI, aiming to expose the majority, if not all the configuration options of SVGO." />
+    <meta name="description" content="SVGOMG is SVGO's Missing GUI, aiming to expose the majority, if not all the configuration options of SVGO.">
   </head>
   <body>
     <div class="app-output">

--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,7 @@
     <link rel="icon" href="imgs/icon.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="SVGOMG">
+    <meta name="description" content="SVGOMG is SVGO's Missing GUI, aiming to expose the majority, if not all the configuration options of SVGO." />
   </head>
   <body>
     <div class="app-output">

--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,7 @@
     <link rel="icon" href="imgs/icon.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="SVGOMG">
-    <meta name="description" content="SVGOMG is SVGO's Missing GUI, aiming to expose the majority, if not all the configuration options of SVGO.">
+    <meta name="description" content="Easy & visual compression of SVG images.">
   </head>
   <body>
     <div class="app-output">


### PR DESCRIPTION
This fixes lighthouse warning for not having a `description` meta tag:

one of #311 

please consider tagging it as 'hacktoberfest-accepted' 🥳