### PR TITLE
Disable `removeViewbox` plugin

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -103,7 +103,7 @@
     {
       "id": "removeViewBox",
       "name": "Remove viewBox",
-      "enabledByDefault": true
+      "enabledByDefault": false
     },
     {
       "id": "cleanupEnableBackground",


### PR DESCRIPTION
While svgo still has this enabled by default, it can cause issues

See https://github.com/svg/svgo/pull/1461 for more details