### PR TITLE
Easier copy/paste from the markup screen

### DIFF
--- a/src/css/_main-layout.scss
+++ b/src/css/_main-layout.scss
@@ -45,6 +45,7 @@
   right: 13px;
   display: flex;
   align-items: center;
+  user-select: none;
 
   .minor-action-container {
     display: flex;

--- a/src/css/components/_main-menu.scss
+++ b/src/css/components/_main-menu.scss
@@ -5,6 +5,7 @@
   bottom: 0;
   right: 0;
   z-index: 3;
+  user-select: none;
 
   &.hidden {
     pointer-events: none;


### PR DESCRIPTION
This pull request goal is to improve the user experience when copying the markup code in the markup screen.
As of today (and discussed in issue #22) some UI text gets copied along with the SVG markup when we use the keystrokes CMD+A —> CMD+C.

There is multiple ways to solve the issue:

- Excluding UI elements with `user-select:none`. Meaning that it will need to be specified if new UI regions appear in the future
- Excluding the whole app with `user-select:none`, and allowing some UI regions with with `user-select:auto`
- Making the output div `contentEditable="true"` but this requires to deactivate autocorrect, autocapitalize & so on. Also, this could lead to side effects whenever the contentEditable API evolves.
- For the future: using user-select:contain. This is CSS4 spec as we speak and [not yet supported by any browser](https://caniuse.com/mdn-css_properties_user-select_contain).

I went with the 1st solution (excluding `.main-menu` and `.action-button-container`) but I can adjust if needed