### PR TITLE
deps: upgrade to svgo v3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgomg",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svgomg",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.2",
@@ -27,7 +27,7 @@
         "sirv-cli": "^2.0.2",
         "stylelint": "^14.14.0",
         "stylelint-config-twbs-bootstrap": "^6.0.0",
-        "svgo": "^3.0.0",
+        "svgo": "^3.0.5",
         "vinyl-map": "^1.0.2",
         "xo": "^0.52.4"
       }
@@ -9628,16 +9628,17 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.0.tgz",
-      "integrity": "sha512-mSqPn6RDeNqJvCeqHERlfWJjd4crP/2PgFelil9WpTwC4D3okAUopPsH3lnEyl7ONXfDVyISOihDjO0uK8YVAA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.5.tgz",
+      "integrity": "sha512-HQKHEo73pMNOlDlBcLgZRcHW2+1wo7bFYayAXkGN0l/2+h68KjlfZyMRhdhaGvoHV2eApOovl12zoFz42sT6rQ==",
       "dev": true,
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.2.1",
-        "csso": "^5.0.5",
+        "css-what": "^6.1.0",
+        "csso": "5.0.5",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -19497,16 +19498,17 @@
       "dev": true
     },
     "svgo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.0.tgz",
-      "integrity": "sha512-mSqPn6RDeNqJvCeqHERlfWJjd4crP/2PgFelil9WpTwC4D3okAUopPsH3lnEyl7ONXfDVyISOihDjO0uK8YVAA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.5.tgz",
+      "integrity": "sha512-HQKHEo73pMNOlDlBcLgZRcHW2+1wo7bFYayAXkGN0l/2+h68KjlfZyMRhdhaGvoHV2eApOovl12zoFz42sT6rQ==",
       "dev": true,
       "requires": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.2.1",
-        "csso": "^5.0.5",
+        "css-what": "^6.1.0",
+        "csso": "5.0.5",
         "picocolors": "^1.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svgomg",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jakearchibald/svgomg.git"
@@ -32,7 +32,7 @@
     "sirv-cli": "^2.0.2",
     "stylelint": "^14.14.0",
     "stylelint-config-twbs-bootstrap": "^6.0.0",
-    "svgo": "^3.0.0",
+    "svgo": "^3.0.5",
     "vinyl-map": "^1.0.2",
     "xo": "^0.52.4"
   },

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "1.17.0",
+    "changes": [
+      "Update to SVGO v3.0.4",
+      "New optimisation: Convert one-stop gradients",
+      "New optimisation: Remove XLink namespace"
+    ]
+  },
+  {
     "version": "1.16.0",
     "changes": [
       "Update to SVGO v3.0.0",

--- a/src/config.json
+++ b/src/config.json
@@ -56,7 +56,7 @@
       "enabledByDefault": false
     },
     {
-      "id": "cleanupIDs",
+      "id": "cleanupIds",
       "name": "Clean up IDs",
       "enabledByDefault": true
     },
@@ -181,16 +181,6 @@
       "enabledByDefault": false
     },
     {
-      "id": "sortAttrs",
-      "name": "Sort attrs",
-      "enabledByDefault": true
-    },
-    {
-      "id": "sortDefsChildren",
-      "name": "Sort children of <defs>",
-      "enabledByDefault": true
-    },
-    {
       "id": "removeTitle",
       "name": "Remove <title>",
       "enabledByDefault": true
@@ -219,6 +209,26 @@
       "id": "removeOffCanvasPaths",
       "name": "Remove out-of-bounds paths",
       "enabledByDefault": false
+    },
+    {
+      "id": "convertOneStopGradients",
+      "name": "Convert one-stop gradients",
+      "enabledByDefault": false
+    },
+    {
+      "id": "removeXlink",
+      "name": "Remove XLink namespace",
+      "enabledByDefault": false
+    },
+    {
+      "id": "sortAttrs",
+      "name": "Sort attrs",
+      "enabledByDefault": true
+    },
+    {
+      "id": "sortDefsChildren",
+      "name": "Sort children of <defs>",
+      "enabledByDefault": true
     }
   ]
 }


### PR DESCRIPTION
This upgrades SVGOMG to use the latest release of SVGO, v3.0.5.

The maintainers (including myself) have spent quite a lot of time resolving some of the long-term bugs that have encumbered the project, particularly in the last two releases. This should resolve some issues reported by users here as well.

* https://github.com/svg/svgo/releases/tag/v3.0.3
* https://github.com/svg/svgo/releases/tag/v3.0.4
* https://github.com/svg/svgo/releases/tag/v3.0.5
 
I've also made some small changes:

* In SVGO v3.0.0, the `cleanupIDs` plugin was renamed to `cleanupIds`, this updates the config to apply that change.
* Move the `sort*` plugins to the end, as this is where they work best.
* Add the two new plugins (disabled by default) to the list, `convertOneStopGradients` and `removeXlink`.