### PR TITLE
half cost of prettifying markup

### DIFF
--- a/src/js/svgo-worker/index.js
+++ b/src/js/svgo-worker/index.js
@@ -65,7 +65,7 @@ function compress(svgInput, settings) {
     multipass: settings.multipass,
     plugins: [...plugins, extractDimensionsPlugin],
     js2svg: {
-      indent: 2,
+      indent: '\t',
       pretty: settings.pretty,
     },
   });


### PR DESCRIPTION
Prettifying the markup has an obvious cost, at the same time the entire purpose of the tool is to reduce the size of an SVG. Since there is a single-byte option for indentation characters that is actually intended to be used for indentation, use that instead.