### PR TITLE
Fix error when showing some special svg due to data url

### DIFF
--- a/src/js/page/ui/svg-output.js
+++ b/src/js/page/ui/svg-output.js
@@ -23,12 +23,10 @@ export default class SvgOutput {
   }
 
   setSvg({ text, width, height }) {
-    // TODO: revisit this
-    // I would rather use blob urls, but they don't work in Firefox
-    // All the internal refs break.
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1125667
     const nextLoad = this._nextLoadPromise();
-    this._svgFrame.src = `data:image/svg+xml,${encodeURIComponent(text)}`;
+    this._svgFrame.src = URL.createObjectURL(
+      new Blob([text], { type: 'image/svg+xml' }),
+    )
     this._svgFrame.style.width = `${width}px`;
     this._svgFrame.style.height = `${height}px`;
     return nextLoad;


### PR DESCRIPTION
Close: #449

The bug https://bugzilla.mozilla.org/show_bug.cgi?id=1125667 in the code comment seems have been fixed.
![image](https://github.com/user-attachments/assets/aa728cfe-f212-4570-8e41-c2e1b3e99df9)

So, it's time to use blob urls. It will resolve the bug #449.