### PR TITLE
fix: Replace iframe location instead of pushing to the history stack.

### DIFF
--- a/src/js/page/ui/svg-output.js
+++ b/src/js/page/ui/svg-output.js
@@ -28,7 +28,11 @@ export default class SvgOutput {
     // All the internal refs break.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1125667
     const nextLoad = this._nextLoadPromise();
-    this._svgFrame.src = `data:image/svg+xml,${encodeURIComponent(text)}`;
+    // Replacing the location instead of pushing to the history stack for every change to the settings.
+    // Context: https://stackoverflow.com/questions/29859048/updating-an-iframe-history-and-url-then-making-it-work-with-back-button
+    this._svgFrame.contentWindow.location.replace(
+      `data:image/svg+xml,${encodeURIComponent(text)}`,
+    );
     this._svgFrame.style.width = `${width}px`;
     this._svgFrame.style.height = `${height}px`;
     return nextLoad;


### PR DESCRIPTION
HI! 👋 
When using SVGOMG I notices that whenever I made a change to the compression settings, a new entry was being pushed to the history stack, essentially making it impossible to go back to the page that referred me to SVGOMG:

<img width="245" alt="Screenshot 2025-01-11 at 19 23 53" src="https://github.com/user-attachments/assets/3457cc8e-3e6a-4cf5-bf17-845b9859b37f" />

# Bug investigation
I put a breakpoint in the event handler of one of the inputs, and eventually found the exact statement causing this problem. Essentially, changing an iframe's src attribute causes a new entry on top of the history stack. Using a slightly different API, the iframe's location can be replaced without adding onto the stack.

# This PR
Introduces a fix that replaces the SVG iframe's location, instead of pushing a new entry to the history stack 💜 