### PR TITLE
React component jsx/tsx generation tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgomg",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svgomg",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.2",

--- a/src/css/_components.scss
+++ b/src/css/_components.scss
@@ -12,5 +12,6 @@
 @import 'components/results';
 @import 'components/output';
 @import 'components/code-output';
+@import 'components/component-output';
 @import 'components/prism';
 @import 'components/ripple';

--- a/src/css/components/_component-output.scss
+++ b/src/css/components/_component-output.scss
@@ -58,17 +58,26 @@
 }
 
 .component-output-toggle {
-  display: inline-flex;
+  flex-basis: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 6px;
+  row-gap: 4px;
   align-items: center;
-  gap: 6px;
-  height: 32px;
-  margin-top: 18px;
   font-size: 0.85rem;
   color: rgba(#fff, 0.85);
 
   input {
     margin: 0;
   }
+}
+
+.component-output-toggle-description {
+  grid-column: 2;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: rgba(#fff, 0.65);
 }
 
 .component-output-btn {

--- a/src/css/components/_component-output.scss
+++ b/src/css/components/_component-output.scss
@@ -1,0 +1,143 @@
+.component-output {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-flow: column;
+  background-color: rgba(#000, 0.8);
+  color: #f8f8f2;
+  opacity: 0;
+  transform: translateZ(0);
+
+  &.transition {
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  &.active {
+    opacity: 1;
+  }
+}
+
+.component-output-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 14px;
+  border-bottom: 1px solid rgba(#fff, 0.1);
+  background-color: rgba(#000, 0.15);
+}
+
+.component-output-field {
+  display: flex;
+  flex-flow: column;
+  gap: 4px;
+}
+
+.component-output-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(#fff, 0.7);
+}
+
+.component-output-input {
+  height: 32px;
+  border-radius: 4px;
+  border: 1px solid rgba(#fff, 0.2);
+  background-color: rgba(#000, 0.25);
+  color: #fff;
+  padding: 0 10px;
+
+  &:focus {
+    outline: none;
+    border-color: rgba(#00bcd4, 0.9);
+  }
+}
+
+.component-output-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  margin-top: 18px;
+  font-size: 0.85rem;
+  color: rgba(#fff, 0.85);
+
+  input {
+    margin: 0;
+  }
+}
+
+.component-output-btn {
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 4px;
+  border: 1px solid rgba(#fff, 0.2);
+  background-color: rgba(#fff, 0.08);
+  color: #fff;
+
+  &:hover {
+    background-color: rgba(#fff, 0.12);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(#00bcd4, 0.9);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
+}
+
+.component-output-messages {
+  padding: 10px 14px 0;
+  display: grid;
+  gap: 6px;
+  min-height: 44px;
+}
+
+.component-output-error {
+  font-size: 0.85rem;
+  color: #ff6b6b;
+}
+
+.component-output-status {
+  font-size: 0.85rem;
+  color: rgba(#fff, 0.85);
+}
+
+.component-output-text {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  border: none;
+  resize: none;
+  padding: 14px;
+  margin: 0;
+  color: #f8f8f2;
+  background: transparent;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  outline: none;
+
+  @media (min-width: 640px) {
+    padding-bottom: 200px;
+  }
+}
+
+@media (min-width: 900px) {
+  .component-output {
+    width: 100vw;
+    padding-right: 380px;
+  }
+
+  .component-output-text {
+    font-size: 1rem;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -101,6 +101,11 @@
             <span class="selected"></span>
             Markup
           </label>
+          <label class="material-tab">
+            <input type="radio" name="output" value="component" />
+            <span class="selected"></span>
+            Component
+          </label>
         </form>
       </div>
       <div class="main">

--- a/src/index.html
+++ b/src/index.html
@@ -104,7 +104,7 @@
           <label class="material-tab">
             <input type="radio" name="output" value="component" />
             <span class="selected"></span>
-            Component
+            React Component
           </label>
         </form>
       </div>

--- a/src/js/page/main-controller.js
+++ b/src/js/page/main-controller.js
@@ -229,6 +229,7 @@ export default class MainController {
     try {
       this._inputItem = await svgo.wrapOriginal(data);
       this._inputFilename = filename;
+      this._outputUi.setInputFilename(filename);
     } catch (error) {
       this._mainMenuUi.stopSpinner();
       this._handleError(new Error(`Load failed: ${error.message}`));

--- a/src/js/page/svg-to-jsx.js
+++ b/src/js/page/svg-to-jsx.js
@@ -1,0 +1,322 @@
+const toPascalCase = (value) =>
+  value
+    .replace(/[^a-zA-Z\d]+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+
+const ensureIconSuffix = (value) =>
+  value.endsWith('Icon') ? value : `${value}Icon`;
+
+const escapeAttributeValue = (value) => value.replace(/"/g, '&quot;');
+
+const camelCase = (value) =>
+  value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+
+const toJsxAttributeName = (name) => {
+  if (name === 'class') return 'className';
+  if (name.startsWith('data-') || name.startsWith('aria-')) return name;
+
+  if (name.includes(':')) {
+    const [prefix, suffix, ...rest] = name.split(':');
+    const tail = [suffix, ...rest].join(':');
+    return `${prefix}${tail.charAt(0).toUpperCase()}${tail.slice(1)}`;
+  }
+
+  return camelCase(name);
+};
+
+const serializeStyleObject = (styleText) => {
+  const entries = styleText
+    .split(';')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [rawProperty, ...rest] = entry.split(':');
+      const rawValue = rest.join(':');
+      const property = rawProperty?.trim();
+      const value = rawValue?.trim();
+      if (!property || !value) return null;
+      const key = property.startsWith('--')
+        ? `'${property}'`
+        : camelCase(property);
+      return `${key}: ${JSON.stringify(value)}`;
+    })
+    .filter(Boolean);
+
+  return entries.length ? `{ ${entries.join(', ')} }` : '{}';
+};
+
+const serializeSvgNodeToJsx = (node, indentLevel) => {
+  const indent = '  '.repeat(indentLevel);
+
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = (node.textContent ?? '').replace(/\s+/g, ' ').trim();
+    if (!text) return [];
+    return [`${indent}{${JSON.stringify(text)}}`];
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) return [];
+
+  const el = node;
+  const tagName = el.tagName;
+
+  const attributes = Array.from(el.attributes)
+    .map((attr) => {
+      const attrName = toJsxAttributeName(attr.name);
+      if (attrName === 'style')
+        return `style={${serializeStyleObject(attr.value)}}`;
+      return `${attrName}="${escapeAttributeValue(attr.value)}"`;
+    })
+    .join(' ');
+
+  const children = Array.from(el.childNodes).flatMap((child) =>
+    serializeSvgNodeToJsx(child, indentLevel + 1)
+  );
+
+  const openTag = attributes ? `<${tagName} ${attributes}` : `<${tagName}`;
+
+  if (children.length === 0) return [`${indent}${openTag} />`];
+
+  return [`${indent}${openTag}>`, ...children, `${indent}</${tagName}>`];
+};
+
+const shouldReplacePaintWithCurrentColor = (value) => {
+  const normalized = value.trim();
+  if (!normalized) return false;
+
+  const lower = normalized.toLowerCase();
+  if (
+    [
+      'none',
+      'transparent',
+      'currentcolor',
+      'inherit',
+      'initial',
+      'unset',
+    ].includes(lower)
+  )
+    return false;
+  if (
+    lower.startsWith('url(') ||
+    lower.startsWith('var(') ||
+    lower.startsWith('context-')
+  )
+    return false;
+
+  if (/^#([\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})$/i.test(normalized))
+    return true;
+  if (/^(rgb|rgba|hsl|hsla|hwb|lab|lch|color)\(/i.test(normalized)) return true;
+  if (/^[a-z]+$/i.test(normalized)) return true;
+
+  return false;
+};
+
+const convertSvgPaintToCurrentColor = (svgElement) => {
+  const elements = [
+    svgElement,
+    ...Array.from(svgElement.querySelectorAll('*')),
+  ];
+
+  for (const el of elements) {
+    for (const attrName of ['fill', 'stroke']) {
+      const value = el.getAttribute(attrName);
+      if (value && shouldReplacePaintWithCurrentColor(value)) {
+        el.setAttribute(attrName, 'currentColor');
+      }
+    }
+
+    for (const attrName of [
+      'fill-opacity',
+      'stroke-opacity',
+      'fillOpacity',
+      'strokeOpacity',
+    ]) {
+      if (el.hasAttribute(attrName)) el.removeAttribute(attrName);
+    }
+
+    const style = el.getAttribute('style');
+    if (!style) continue;
+
+    const entries = style
+      .split(';')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    let changed = false;
+    const nextEntries = entries
+      .map((entry) => {
+        const [rawProperty, ...rest] = entry.split(':');
+        const property = rawProperty?.trim();
+        const rawValue = rest.join(':');
+        const paintValue = rawValue?.trim();
+        if (!property || !paintValue) return entry;
+
+        const lowerProperty = property.toLowerCase();
+        if (
+          lowerProperty === 'fill-opacity' ||
+          lowerProperty === 'fillopacity'
+        ) {
+          changed = true;
+          return null;
+        }
+
+        if (
+          lowerProperty === 'stroke-opacity' ||
+          lowerProperty === 'strokeopacity'
+        ) {
+          changed = true;
+          return null;
+        }
+
+        if (
+          (lowerProperty === 'fill' || lowerProperty === 'stroke') &&
+          shouldReplacePaintWithCurrentColor(paintValue)
+        ) {
+          changed = true;
+          return `${property}:currentColor`;
+        }
+
+        return `${property}:${rawValue.trim()}`;
+      })
+      .filter(Boolean);
+
+    if (!changed) continue;
+
+    if (nextEntries.length) {
+      el.setAttribute('style', nextEntries.join(';'));
+    } else {
+      el.removeAttribute('style');
+    }
+  }
+};
+
+const parseSvgMarkup = (svgMarkup, options) => {
+  if (typeof DOMParser === 'undefined') {
+    throw new TypeError('DOMParser is not available in this browser.');
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgMarkup, 'image/svg+xml');
+  const parserError = doc.querySelector('parsererror');
+  if (parserError)
+    throw new Error(
+      'SVG parsing failed. Make sure you pasted valid SVG markup.'
+    );
+
+  const svgElement = doc.querySelector('svg');
+  if (!svgElement) throw new Error('No <svg> root element found.');
+
+  if (options?.convertPaintToCurrentColor) {
+    convertSvgPaintToCurrentColor(svgElement);
+  }
+
+  return svgElement;
+};
+
+const getDefaultSize = (svgElement) => {
+  const viewBox = svgElement.getAttribute('viewBox') ?? undefined;
+  const width = svgElement.getAttribute('width') ?? undefined;
+  const height = svgElement.getAttribute('height') ?? undefined;
+
+  const parseNumeric = (value) => {
+    if (!value) return undefined;
+    const numeric = Number(value.replace('px', '').trim());
+    return Number.isFinite(numeric) ? numeric : undefined;
+  };
+
+  const sizeFromWidth = parseNumeric(width);
+  const sizeFromHeight = parseNumeric(height);
+  const sizeFromViewBox = (() => {
+    if (!viewBox) return undefined;
+    const parts = viewBox.split(/[\s,]+/).map(Number);
+    if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part)))
+      return undefined;
+    return Math.max(parts[2], parts[3]);
+  })();
+
+  return sizeFromWidth ?? sizeFromHeight ?? sizeFromViewBox ?? 24;
+};
+
+const serializeRootAttributes = (svgElement) => {
+  const rootAttributes = Array.from(svgElement.attributes)
+    .filter(
+      (attr) => !['width', 'height', 'class', 'style'].includes(attr.name)
+    )
+    .map((attr) => {
+      const attrName = toJsxAttributeName(attr.name);
+      if (attrName === 'style')
+        return `style={${serializeStyleObject(attr.value)}}`;
+      return `${attrName}="${escapeAttributeValue(attr.value)}"`;
+    });
+
+  if (!rootAttributes.some((attr) => attr.startsWith('xmlns='))) {
+    rootAttributes.unshift('xmlns="http://www.w3.org/2000/svg"');
+  }
+
+  if (!rootAttributes.some((attr) => attr.startsWith('viewBox='))) {
+    rootAttributes.push('viewBox="0 0 24 24"');
+  }
+
+  return rootAttributes;
+};
+
+export const generateReactComponentFromSvg = (
+  rawName,
+  svgMarkup,
+  options = {}
+) => {
+  const baseName = toPascalCase(rawName);
+  if (!baseName) throw new Error('Enter a component name.');
+
+  const componentName =
+    options.ensureIconSuffix === false ? baseName : ensureIconSuffix(baseName);
+
+  const svgElement = parseSvgMarkup(svgMarkup, {
+    convertPaintToCurrentColor: options.convertPaintToCurrentColor,
+  });
+
+  const defaultSize = getDefaultSize(svgElement);
+  const rootAttributes = serializeRootAttributes(svgElement);
+  const children = Array.from(svgElement.childNodes).flatMap((child) =>
+    serializeSvgNodeToJsx(child, 2)
+  );
+
+  const isTypeScript = options.typescript !== false;
+  const propsType = isTypeScript ? `: ${componentName}Props` : '';
+
+  const componentSource = [
+    `import * as React from 'react';`,
+    ``,
+    ...(isTypeScript
+      ? [
+          `export type ${componentName}Props = React.SVGProps<SVGSVGElement> & {`,
+          `  size?: string | number;`,
+          `};`,
+          ``,
+        ]
+      : []),
+    `export const ${componentName} = ({ className, size = ${defaultSize}, ...props }${propsType}) => (`,
+    `  <svg`,
+    ...rootAttributes.map((attr) => `    ${attr}`),
+    `    width={size}`,
+    `    height={size}`,
+    `    className={className}`,
+    `    {...props}`,
+    `  >`,
+    ...children,
+    `  </svg>`,
+    `);`,
+    ``,
+  ].join('\n');
+
+  const extension = isTypeScript ? 'tsx' : 'jsx';
+
+  return {
+    componentName,
+    componentSource,
+    fileName: `${componentName}.${extension}`,
+  };
+};

--- a/src/js/page/ui/component-output.js
+++ b/src/js/page/ui/component-output.js
@@ -1,0 +1,260 @@
+import { strToEl } from '../utils.js';
+import { generateReactComponentFromSvg } from '../svg-to-jsx.js';
+
+const suggestNameFromFilename = (filename) => {
+  if (!filename) return '';
+  const base = filename.replace(/\.[a-z\d]+$/i, '');
+  return base
+    .replace(/[^a-zA-Z\d]+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+};
+
+const getFileExtension = (fileName) => {
+  if (fileName.toLowerCase().endsWith('.tsx')) return 'tsx';
+  if (fileName.toLowerCase().endsWith('.jsx')) return 'jsx';
+  return 'txt';
+};
+
+const saveTextFile = async ({ fileName, content }) => {
+  const showSaveFilePicker = window.showSaveFilePicker;
+
+  if (showSaveFilePicker) {
+    const extension = getFileExtension(fileName);
+    const handle = await showSaveFilePicker({
+      suggestedName: fileName,
+      types: [
+        {
+          description: extension.toUpperCase(),
+          accept: { 'text/plain': [`.${extension}`] },
+        },
+      ],
+    });
+
+    const writable = await handle.createWritable();
+    await writable.write(content);
+    await writable.close();
+    return;
+  }
+
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    anchor.style.display = 'none';
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};
+
+const copyText = async (text) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const pre = document.createElement('pre');
+  pre.textContent = text;
+  document.body.append(pre);
+  getSelection().removeAllRanges();
+
+  const range = document.createRange();
+  range.selectNode(pre);
+  getSelection().addRange(range);
+  document.execCommand('copy');
+  getSelection().removeAllRanges();
+  pre.remove();
+};
+
+export default class ComponentOutput {
+  constructor() {
+    // prettier-ignore
+    this.container = strToEl(
+      '<div class="component-output">' +
+        '<div class="component-output-toolbar">' +
+          '<label class="component-output-field">' +
+            '<span class="component-output-label">Name</span>' +
+            '<input class="component-output-input component-output-name" type="text" spellcheck="false" placeholder="e.g. NewFeature" />' +
+          '</label>' +
+          '<label class="component-output-field">' +
+            '<span class="component-output-label">Format</span>' +
+            '<select class="component-output-input component-output-format">' +
+              '<option value="tsx" selected>TSX</option>' +
+              '<option value="jsx">JSX</option>' +
+            '</select>' +
+          '</label>' +
+          '<label class="component-output-toggle">' +
+            '<input class="component-output-currentcolor" type="checkbox" />' +
+            'currentColor' +
+          '</label>' +
+          '<button class="unbutton component-output-btn component-output-generate" type="button">Generate</button>' +
+          '<button class="unbutton component-output-btn component-output-save" type="button" disabled>Save</button>' +
+          '<button class="unbutton component-output-btn component-output-copy" type="button" disabled>Copy</button>' +
+        '</div>' +
+        '<div class="component-output-messages">' +
+          '<div class="component-output-error" role="status" aria-live="polite"></div>' +
+          '<div class="component-output-status" role="status" aria-live="polite"></div>' +
+        '</div>' +
+        '<textarea class="component-output-text" readonly spellcheck="false"></textarea>' +
+      '</div>'
+    );
+
+    this._svgFile = null;
+    this._generated = null;
+    this._autoRegenerate = false;
+
+    this._nameInput = this.container.querySelector('.component-output-name');
+    this._formatSelect = this.container.querySelector(
+      '.component-output-format'
+    );
+    this._currentColorInput = this.container.querySelector(
+      '.component-output-currentcolor'
+    );
+    this._generateBtn = this.container.querySelector(
+      '.component-output-generate'
+    );
+    this._saveBtn = this.container.querySelector('.component-output-save');
+    this._copyBtn = this.container.querySelector('.component-output-copy');
+    this._errorEl = this.container.querySelector('.component-output-error');
+    this._statusEl = this.container.querySelector('.component-output-status');
+    this._textArea = this.container.querySelector('.component-output-text');
+
+    this._nameInput.addEventListener('input', () => this._onOptionsChange());
+    this._formatSelect.addEventListener('change', () =>
+      this._onOptionsChange()
+    );
+    this._currentColorInput.addEventListener('change', () =>
+      this._onOptionsChange()
+    );
+
+    this._generateBtn.addEventListener('click', () => this._generate());
+    this._saveBtn.addEventListener('click', () => this._save());
+    this._copyBtn.addEventListener('click', () => this._copy());
+  }
+
+  setInputFilename(filename) {
+    if (!this._nameInput.value.trim()) {
+      this._nameInput.value = suggestNameFromFilename(filename);
+    }
+  }
+
+  setSvg(svgFile) {
+    this._svgFile = svgFile;
+
+    if (this._autoRegenerate) {
+      this._generate({ preserveStatus: true });
+    } else {
+      this._setGenerated(null);
+    }
+  }
+
+  reset() {
+    this._svgFile = null;
+    this._setGenerated(null);
+    this._setError(null);
+    this._setStatus(null);
+    this._autoRegenerate = false;
+  }
+
+  _onOptionsChange() {
+    if (!this._autoRegenerate) {
+      this._setGenerated(null);
+      return;
+    }
+
+    this._generate({ preserveStatus: true });
+  }
+
+  _setError(message) {
+    this._errorEl.textContent = message || '';
+  }
+
+  _setStatus(message) {
+    this._statusEl.textContent = message || '';
+  }
+
+  _setGenerated(nextGenerated) {
+    this._generated = nextGenerated;
+    this._textArea.value = nextGenerated?.componentSource ?? '';
+    const hasGenerated = Boolean(nextGenerated);
+    this._saveBtn.disabled = !hasGenerated;
+    this._copyBtn.disabled = !hasGenerated;
+  }
+
+  _generate({ preserveStatus = false } = {}) {
+    if (!preserveStatus) {
+      this._setError(null);
+      this._setStatus(null);
+    }
+
+    const name = this._nameInput.value;
+    const svgMarkup = this._svgFile?.text;
+
+    if (!svgMarkup) {
+      this._setGenerated(null);
+      this._setError('Load an SVG first.');
+      return;
+    }
+
+    try {
+      const generated = generateReactComponentFromSvg(name, svgMarkup, {
+        typescript: this._formatSelect.value === 'tsx',
+        convertPaintToCurrentColor: this._currentColorInput.checked,
+      });
+
+      this._autoRegenerate = true;
+      this._setGenerated(generated);
+      this._setError(null);
+      if (!preserveStatus) this._setStatus(`Generated ${generated.fileName}`);
+    } catch (error) {
+      this._setGenerated(null);
+      this._setError(
+        error instanceof Error ? error.message : 'Failed to generate component.'
+      );
+    }
+  }
+
+  async _save() {
+    if (!this._generated) return;
+
+    this._setError(null);
+    this._setStatus(null);
+
+    try {
+      await saveTextFile({
+        fileName: this._generated.fileName,
+        content: this._generated.componentSource,
+      });
+      this._setStatus(`Saved ${this._generated.fileName}`);
+    } catch (error) {
+      this._setError(
+        error instanceof Error ? error.message : 'Failed to save file.'
+      );
+    }
+  }
+
+  async _copy() {
+    if (!this._generated) return;
+
+    this._setError(null);
+    this._setStatus(null);
+
+    try {
+      await copyText(this._generated.componentSource);
+      this._setStatus(`Copied ${this._generated.fileName}`);
+    } catch (error) {
+      this._setError(
+        error instanceof Error ? error.message : 'Failed to copy.'
+      );
+    }
+  }
+}

--- a/src/js/page/ui/component-output.js
+++ b/src/js/page/ui/component-output.js
@@ -92,13 +92,14 @@ export default class ComponentOutput {
               '<option value="jsx">JSX</option>' +
             '</select>' +
           '</label>' +
-          '<label class="component-output-toggle">' +
-            '<input class="component-output-currentcolor" type="checkbox" />' +
-            'currentColor' +
-          '</label>' +
           '<button class="unbutton component-output-btn component-output-generate" type="button">Generate</button>' +
           '<button class="unbutton component-output-btn component-output-save" type="button" disabled>Save</button>' +
           '<button class="unbutton component-output-btn component-output-copy" type="button" disabled>Copy</button>' +
+          '<label class="component-output-toggle">' +
+            '<input class="component-output-currentcolor" type="checkbox" />' +
+            '<span class="component-output-toggle-title">currentColor</span>' +
+            '<span class="component-output-toggle-description">Only replaces explicit color values. Leaves none and missing values as-is.</span>' +
+          '</label>' +
         '</div>' +
         '<div class="component-output-messages">' +
           '<div class="component-output-error" role="status" aria-live="polite"></div>' +

--- a/src/js/page/ui/output.js
+++ b/src/js/page/ui/output.js
@@ -1,6 +1,7 @@
 import { strToEl, transitionToClass, transitionFromClass } from '../utils.js';
 import SvgOutput from './svg-output.js';
 import CodeOutput from './code-output.js';
+import ComponentOutput from './component-output.js';
 
 export default class Output {
   constructor() {
@@ -9,11 +10,17 @@ export default class Output {
     this._types = {
       image: new SvgOutput(),
       code: new CodeOutput(),
+      component: new ComponentOutput(),
     };
 
     this._svgFile = null;
     this._switchQueue = Promise.resolve();
     this.set('image', { noAnimate: true });
+  }
+
+  setInputFilename(filename) {
+    const componentOutput = this._types.component;
+    componentOutput.setInputFilename(filename);
   }
 
   update(svgFile) {


### PR DESCRIPTION
I used this tool to build up a way to autogenerate Icons and stories for a project. Since I was using this tool. I wanted to also add the extension we built to this page. To allow for others to enjoy it.

There are two generation possibilities. You can just have the ability to just generate the svg as is into a tsx or jsx component. The other way is clicking the currentColor checkbox. That changes all internal stroke and fill to currentColor to allow for the icons to change depending on className.

There is a copy button and a save button to choose where in your filesystem to save.

If this is unwanted, just delete it. If you think it's neat merge it and let people use it.

#439 is what I added it for.